### PR TITLE
Typo fix + doc clarification.

### DIFF
--- a/lib/MooseX/AttributeShortcuts.pm
+++ b/lib/MooseX/AttributeShortcuts.pm
@@ -446,7 +446,7 @@ Specifying C<predicate =E<gt> 1> will cause the following options to be set:
 
 or, if your attribute name begins with an underscore:
 
-    predicate => "_has$name"
+    predicate => "_has_$name"
 
 (that is, an attribute named "_foo" would get "_has_foo")
 

--- a/lib/MooseX/AttributeShortcuts.pm
+++ b/lib/MooseX/AttributeShortcuts.pm
@@ -395,6 +395,8 @@ Specifying C<is =E<gt> 'rwp'> will cause the following options to be set:
     is     => 'ro'
     writer => "_set_$name"
 
+rwp can be read as "read + write private".
+
 =head2 is => 'lazy'
 
 Specifying C<is =E<gt> 'lazy'> will cause the following options to be set:


### PR DESCRIPTION
Had to ask what rwp meant on #moose, so I figured it was worthwhile adding a note to the docs.