### PR TITLE
Remove use of autobox

### DIFF
--- a/lib/MooseX/AttributeShortcuts.pm
+++ b/lib/MooseX/AttributeShortcuts.pm
@@ -20,8 +20,6 @@ use Moose::Util::TypeConstraints;
     use MooseX::Types::Moose          ':all';
     use MooseX::Types::Common::String ':all';
 
-    use autobox::Core;
-    use autobox::Junctions;
     use List::AllUtils 'any';
 
     use Package::DeprecationManager -deprecations => {
@@ -102,7 +100,7 @@ use Moose::Util::TypeConstraints;
                 }
             }
 
-            if (any { $options->keys->any eq $_ } (qw{ isa_class isa_role isa_enum })) {
+            if (any { exists $options->{$_} } (qw{ isa_class isa_role isa_enum })) {
 
                 # (more than) fair warning...
                 deprecated(

--- a/t/handles-coderef.t
+++ b/t/handles-coderef.t
@@ -11,10 +11,6 @@ use Test::Moose::More;
     use namespace::autoclean;
     use MooseX::AttributeShortcuts;
 
-    # debugging...
-    use Smart::Comments '###';
-
-
     has foo => (
         is  => 'ro',
         isa => 'Int',


### PR DESCRIPTION
autobox was only used in one location, and it was being misused there anyway.  Remove it to reduce prerequisite load.